### PR TITLE
회원가입 테스트 코드 (#31)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,8 @@ black = "*"
 flake8 = "*"
 pre-commit = "*"
 django-redis = "*"
+pytest = "*"
+pytest-django = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "89aa6f8baf338717915f5f75daefa12f47cd9867d88cbbeeb4442e2873ec037e"
+            "sha256": "c5665453d3e28b27e63d739bcb70d31d1dd1305e1602c2fb34059ff866ed7324"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -31,6 +31,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==4.0.2"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
+                "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==22.2.0"
         },
         "black": {
             "hashes": [
@@ -227,6 +235,14 @@
             "index": "pypi",
             "version": "==5.2.2"
         },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e",
+                "sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.1.0"
+        },
         "filelock": {
             "hashes": [
                 "sha256:7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de",
@@ -259,6 +275,14 @@
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
         },
+        "iniconfig": {
+            "hashes": [
+                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
+        },
         "isort": {
             "hashes": [
                 "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504",
@@ -277,10 +301,11 @@
         },
         "mypy-extensions": {
             "hashes": [
-                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
-                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+                "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
+                "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"
             ],
-            "version": "==0.4.3"
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.0"
         },
         "mysqlclient": {
             "hashes": [
@@ -327,6 +352,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.6.2"
         },
+        "pluggy": {
+            "hashes": [
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.0"
+        },
         "pre-commit": {
             "hashes": [
                 "sha256:9e3255edb0c9e7fe9b4f328cb3dc86069f8fdc38026f1bf521018a05eaf4d67b",
@@ -358,6 +391,22 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.6.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5",
+                "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42"
+            ],
+            "index": "pypi",
+            "version": "==7.2.1"
+        },
+        "pytest-django": {
+            "hashes": [
+                "sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e",
+                "sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2"
+            ],
+            "index": "pypi",
+            "version": "==4.5.2"
         },
         "python-dotenv": {
             "hashes": [

--- a/apps/user/tests.py
+++ b/apps/user/tests.py
@@ -1,1 +1,0 @@
-# from django.test import TestCase

--- a/apps/user/tests/conftest.py
+++ b/apps/user/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.fixture
+def account(django_user_model):
+    account = django_user_model.objects.create_user(email="test@gmail.com")
+    account.set_password("!test12345678")
+    account.save()
+    return account

--- a/apps/user/tests/test_user_signup.py
+++ b/apps/user/tests/test_user_signup.py
@@ -1,0 +1,112 @@
+import json
+
+import pytest
+from rest_framework.reverse import reverse
+
+
+@pytest.mark.django_db
+def test_user_signup_success(client):
+    url = reverse("user:user_signup")
+
+    data = {"email": "test_register@gmail.com", "password": "!test12345678"}
+
+    response = client.post(url, data=data)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 201
+    assert data["message"] == "회원가입에 성공했습니다."
+
+
+@pytest.mark.django_db
+def test_user_signup_fail_with_invalid_email_format(client):
+    url = reverse("user:user_signup")
+
+    data = {"email": "not_match_to_email_foramt", "password": "!test12345678"}
+
+    response = client.post(url, data=data)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 400
+    assert data["email"][0] == "유효한 이메일 주소를 입력하십시오."
+
+
+@pytest.mark.django_db
+def test_user_signup_fail_with_existed_email(client, account):
+    url = reverse("user:user_signup")
+
+    data = {"email": "test@gmail.com", "password": "!test12345678"}
+
+    response = client.post(url, data=data)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 400
+    assert data["email"][0] == "user의 email은/는 이미 존재합니다."
+
+
+@pytest.mark.django_db
+def test_user_signup_fail_with_invalid_password(client):
+    url = reverse("user:user_signup")
+
+    data = {"email": "test_register@gmail.com", "password": "not_match_to_regex"}
+
+    response = client.post(url, data=data)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 400
+    assert data["non_field_errors"][0] == "문자, 숫자, 기호를 조합하여 8자 이상을 사용하세요."
+
+
+@pytest.mark.django_db
+def test_user_signup_fail_with_no_email(client):
+    url = reverse("user:user_signup")
+
+    data = {
+        # "email": "test_register@gmail.com",
+        "password": "!test12345678"
+    }
+
+    response = client.post(url, data=data)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 400
+    assert data["email"][0] == "이 필드는 필수 항목입니다."
+
+
+@pytest.mark.django_db
+def test_user_signup_fail_with_no_password(client):
+    url = reverse("user:user_signup")
+
+    data = {
+        "email": "test_register@gmail.com",
+        # "password": "!test12345678"
+    }
+
+    response = client.post(url, data=data)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 400
+    assert data["password"][0] == "이 필드는 필수 항목입니다."
+
+
+@pytest.mark.django_db
+def test_user_signup_fail_with_no_email_and_password(client):
+    url = reverse("user:user_signup")
+
+    data = {
+        # "email": "test_register@gmail.com",
+        # "password": "!test12345678"
+    }
+
+    response = client.post(url, data=data)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 400
+    assert data["email"][0] == "이 필드는 필수 항목입니다."
+    assert data["password"][0] == "이 필드는 필수 항목입니다."

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = config.settings
+python_files = tests.py test_*.py *_tests.py
+django_debug_mode = true
+filterwarnings =
+    ignore::django.utils.deprecation.RemovedInDjango50Warning
+    ignore::RuntimeWarning


### PR DESCRIPTION
### Types of changes

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 테스트케이스
- [ ] 컨벤션 수정
- [ ] 문서
- [ ] CI/CD
- [ ] 리팩토링

### Summary

- 회원가입 테스트 코드를 작성합니다.

<br>

- 회원가입 성공
- 회원가입 실패 (email format 불일치)
- 회원가입 실패 (이미 존재하는 email)
- 회원가입 실패 (비밀번호 정규표현식 (8-20자, 문자, 숫자, 기호 포함) 통과 X)
- 회원가입 실패 (이메일 값 넣지 않음)
- 회원가입 실패 (패스워드 값 넣지 않음)
- 회원가입 실패 (이메일, 패스워드 값 넣지 않음)

### Changes

- pytest, pytest-django 라이브러리를 설치하고 설정파일 pytest.ini을 추가


### 특이사항 (Optional)

-

### Screenshots (Optional)

<img width="1386" alt="스크린샷 2023-02-06 오후 1 12 00" src="https://user-images.githubusercontent.com/83942213/216882725-ee97b308-4bcf-4b1e-9bfa-dc040c495923.png">
