### PR TITLE
test: 토큰 재발급 (#37)

### DIFF
--- a/apps/user/tests/conftest.py
+++ b/apps/user/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from rest_framework.reverse import reverse
 
 
 @pytest.fixture
@@ -7,3 +8,15 @@ def account(django_user_model):
     account.set_password("!test12345678")
     account.save()
     return account
+
+
+@pytest.fixture
+def login(client, account):
+    data = {"email": "test@gmail.com", "password": "!test12345678"}
+
+    response = client.post(reverse("user:user_signin"), data=data)
+
+    access_token = response.data["access_token"]
+    refresh_token = response.data["refresh_token"]
+
+    return access_token, refresh_token

--- a/apps/user/tests/test_user_signout.py
+++ b/apps/user/tests/test_user_signout.py
@@ -5,17 +5,9 @@ from rest_framework.reverse import reverse
 
 
 @pytest.mark.django_db
-def test_user_signout_success(client, account):
-    # 로그인
-    data = {"email": "test@gmail.com", "password": "!test12345678"}
+def test_user_signout_success(client, login):
+    access_token, refresh_token = login
 
-    login = client.post(reverse("user:user_signin"), data=data)
-
-    assert login.status_code == 200
-    access_token = login.data["access_token"]
-    refresh_token = login.data["refresh_token"]
-
-    # 로그아웃
     headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
     data = {"refresh_token": refresh_token}
 
@@ -27,17 +19,9 @@ def test_user_signout_success(client, account):
 
 
 @pytest.mark.django_db
-def test_user_signout_fail_with_blacklisted_token(client, account):
-    # 로그인
-    data = {"email": "test@gmail.com", "password": "!test12345678"}
+def test_user_signout_fail_with_blacklisted_token(client, login):
+    access_token, refresh_token = login
 
-    login = client.post(reverse("user:user_signin"), data=data)
-
-    assert login.status_code == 200
-    access_token = login.data["access_token"]
-    refresh_token = login.data["refresh_token"]
-
-    # 로그아웃
     headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
     data = {"refresh_token": refresh_token}
 

--- a/apps/user/tests/test_user_token_refresh.py
+++ b/apps/user/tests/test_user_token_refresh.py
@@ -1,0 +1,35 @@
+import json
+
+import pytest
+from rest_framework.reverse import reverse
+
+
+@pytest.mark.django_db
+def test_user_token_refresh_success(client, login):
+    access_token, refresh_token = login
+
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    data = {"refresh": refresh_token}
+
+    response = client.post(reverse("user:token_refresh"), data=data, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code
+    assert data["access"]
+
+
+@pytest.mark.django_db
+def test_user_token_refresh_fail_with_invalid_refresh_token(client, login):
+    access_token, refresh_token = login
+
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    data = {"refresh": "invalid_refresh_token"}
+
+    response = client.post(reverse("user:token_refresh"), data=data, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 401
+    assert data["code"] == "token_not_valid"
+    assert data["detail"] == "유효하지 않거나 만료된 토큰"


### PR DESCRIPTION
### Types of changes

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 테스트케이스
- [ ] 컨벤션 수정
- [ ] 문서
- [ ] CI/CD
- [ ] 리팩토링

### Summary

- 토큰 재발급기능의 테스트코드를 작성합니다.

<br>
- 토큰 재발급 성공
- 토큰 재발급 실패 (잘못된 refresh_token으로 요청)

### Changes

- 토큰을 받아오는부분을 fixtrue로 만들었습니다.
- 로그아웃 테스트코드에서 해당부분을 테스트코드 내 직접호출에서 fixture에서 값을 가져오게 변경했습니다.


### 특이사항 (Optional)

-

### Screenshots (Optional)

<img width="1387" alt="토큰재발급" src="https://user-images.githubusercontent.com/83942213/216952598-6767dabe-246e-4abd-a902-298d98036caf.png">

- 토큰 재발급

<img width="1380" alt="signout " src="https://user-images.githubusercontent.com/83942213/216952615-9701d72a-d3b3-4113-846c-7532e823da44.png">

- 로그아웃 테스트코드 수정 후 통과 확인