### PR TITLE
test: 가계부, 가계부 메모 (#39)

### DIFF
--- a/apps/account_book/tests/conftest.py
+++ b/apps/account_book/tests/conftest.py
@@ -1,0 +1,76 @@
+import pytest
+from rest_framework.reverse import reverse
+
+from apps.account_book.models import AccountBook, AccountBookRecord
+
+
+@pytest.fixture
+def account(django_user_model):
+    account = django_user_model.objects.create_user(email="test@gmail.com")
+    account.set_password("!test12345678")
+    account.save()
+    return account
+
+
+@pytest.fixture
+def account_b(django_user_model):
+    account = django_user_model.objects.create_user(email="test_b@gmail.com")
+    account.set_password("!test12345678")
+    account.save()
+    return account
+
+
+@pytest.fixture
+def account_book(account, django_user_model):
+    user = django_user_model.objects.get(id=account.id)
+    account_book = AccountBook.objects.create(user=user, title="test_title")
+    return account_book
+
+
+@pytest.fixture
+def account_book_record(account_book):
+    account_book = AccountBook.objects.get(id=account_book.id)
+    account_book_record = AccountBookRecord.objects.create(
+        account_book=account_book, date="2023-01-01", amount=1, description="test_description"
+    )
+    return account_book_record
+
+
+@pytest.fixture
+def deleted_account_book_record(account_book):
+    account_book = AccountBook.objects.get(id=account_book.id)
+    deleted_account_book_record = AccountBookRecord.objects.create(
+        account_book=account_book, date="2023-01-01", amount=1, description="test_description", is_active=False
+    )
+    return deleted_account_book_record
+
+
+@pytest.fixture
+def deleted_account_book(account, django_user_model):
+    user = django_user_model.objects.get(id=account.id)
+    account_book = AccountBook.objects.create(user=user, title="test_title_deleted", is_active=False)
+    return account_book
+
+
+@pytest.fixture
+def login(client, account):
+    data = {"email": "test@gmail.com", "password": "!test12345678"}
+
+    response = client.post(reverse("user:user_signin"), data=data)
+
+    access_token = response.data["access_token"]
+    refresh_token = response.data["refresh_token"]
+
+    return access_token, refresh_token
+
+
+@pytest.fixture
+def login_b(client, account_b):
+    data = {"email": "test_b@gmail.com", "password": "!test12345678"}
+
+    response = client.post(reverse("user:user_signin"), data=data)
+
+    access_token = response.data["access_token"]
+    refresh_token = response.data["refresh_token"]
+
+    return access_token, refresh_token

--- a/apps/account_book/tests/test_account_book.py
+++ b/apps/account_book/tests/test_account_book.py
@@ -1,0 +1,77 @@
+import json
+
+from rest_framework.reverse import reverse
+
+
+def test_account_book_create_success(client, login):
+    url = reverse("account_book:account_book")
+    access_token, refresh_token = login
+
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    data = {
+        "title": "test_title",
+        "balance": 1,
+    }
+    response = client.post(url, data=data, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 201
+    assert data["title"] == "test_title"
+    assert data["balance"] == 1
+
+
+def test_account_book_create_fail_with_unauthenticated(client):
+    url = reverse("account_book:account_book")
+    access_token = "invalid_token"
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+
+    data = {"title": "test_title", "balance": 1}
+    response = client.post(url, data=data, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 401
+
+
+def test_account_book_create_fail_with_no_data(client, login):
+    url = reverse("account_book:account_book")
+    access_token, refresh_token = login
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+
+    data = {}
+    response = client.post(url, data=data, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 400
+    assert data["title"][0] == "이 필드는 필수 항목입니다."
+
+
+def test_account_book_list_read_success(client, account_book, login):
+    url = reverse("account_book:account_book")
+
+    access_token, refresh_token = login
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+
+    response = client.get(url, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 200
+    assert data[0]["title"] == "test_title"
+    assert data[0]["balance"] == 0
+
+
+def test_account_book_list_read_fail_with_no_authentication(client):
+    url = reverse("account_book:account_book")
+
+    access_token = None
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+
+    response = client.get(url, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 401
+    assert data["detail"] == "이 토큰은 모든 타입의 토큰에 대해 유효하지 않습니다"

--- a/apps/account_book/tests/test_account_book_detail.py
+++ b/apps/account_book/tests/test_account_book_detail.py
@@ -1,0 +1,87 @@
+import json
+
+from rest_framework.reverse import reverse
+
+
+def test_account_book_detail_read_success(client, account_book, login):
+    url = reverse("account_book:account_book_detail", kwargs={"pk": account_book.id})
+
+    access_token, refresh_token = login
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+
+    response = client.get(url, **headers)
+    data = json.loads(response.content)
+
+    assert response.status_code == 200
+    assert data["title"] == "test_title"
+    assert data["balance"] == 0
+    assert data["is_active"] == True
+
+
+def test_account_book_detail_read_fail_with_unauthorized_user(client, account_book, login_b):
+    url = reverse("account_book:account_book_detail", kwargs={"pk": account_book.id})
+
+    access_token, refresh_token = login_b
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+
+    response = client.get(url, **headers)
+    data = json.loads(response.content)
+
+    assert response.status_code == 403
+    assert data["detail"] == "이 작업을 수행할 권한(permission)이 없습니다."
+
+
+def test_account_book_detail_update_success(client, account_book, login):
+    url = reverse("account_book:account_book_detail", kwargs={"pk": account_book.id})
+
+    access_token, refresh_token = login
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    data = {"balance": 111, "title": "updated_title"}
+    response = client.patch(url, data=data, content_type="application/json", **headers)
+    data = json.loads(response.content)
+
+    assert response.status_code == 200
+    assert data["title"] == "updated_title"
+    assert data["balance"] == 111
+    assert data["updated_at"]
+
+
+def test_account_book_detail_update_fail_with_no_data(client, account_book, login):
+    url = reverse("account_book:account_book_detail", kwargs={"pk": account_book.id})
+
+    access_token, refresh_token = login
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    data = {
+        # "balance": 111,
+        # "title": "updated_title"
+    }
+    response = client.patch(url, data=data, content_type="application/json", **headers)
+    data = json.loads(response.content)
+
+    assert response.status_code == 400
+    assert data["non_field_errors"][0] == "입력값이 없습니다."
+
+
+def test_account_book_detail_delete_success(client, account_book, login):
+    url = reverse("account_book:account_book_detail", kwargs={"pk": account_book.id})
+
+    access_token, refresh_token = login
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    response = client.delete(url, **headers)
+    data = json.loads(response.content)
+
+    assert response.status_code == 200
+    assert data["is_active"] == False
+    assert data["deleted_at"]
+
+
+def test_account_book_detail_delete_fail_with_deleted_account_book(client, deleted_account_book, login):
+    url = reverse("account_book:account_book_detail", kwargs={"pk": deleted_account_book.id})
+
+    access_token, refresh_token = login
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    response = client.delete(url, **headers)
+    data = json.loads(response.content)
+
+    assert response.status_code == 400
+    assert data[0] == "이미 삭제된 가계부 입니다."

--- a/apps/account_book/tests/test_account_book_record.py
+++ b/apps/account_book/tests/test_account_book_record.py
@@ -1,0 +1,97 @@
+import json
+
+from rest_framework.reverse import reverse
+
+
+def test_account_book_record_create_success(client, account_book, login):
+    url = reverse("account_book:account_book_record", kwargs={"pk": account_book.id})
+    access_token, refresh_token = login
+
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    data = {"date": "2023-01-01", "amount": 1, "description": "test_description"}
+    response = client.post(url, data=data, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 201
+    assert data["date"] == "2023-01-01"
+    assert data["amount"] == 1
+    assert data["description"] == "test_description"
+
+
+def test_account_book_record_create_fail_with_no_data(client, account_book, login):
+    url = reverse("account_book:account_book_record", kwargs={"pk": account_book.id})
+    access_token, refresh_token = login
+
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    data = {
+        # "date": "2023-01-01",
+        # "amount": 1,
+        # "description": "test_description"
+    }
+    response = client.post(url, data=data, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 400
+    assert data["date"][0] == "이 필드는 필수 항목입니다."
+    assert data["amount"][0] == "이 필드는 필수 항목입니다."
+    assert data["description"][0] == "이 필드는 필수 항목입니다."
+
+
+def test_account_book_record_create_fail_with_invalid_date_format(client, account_book, login):
+    url = reverse("account_book:account_book_record", kwargs={"pk": account_book.id})
+    access_token, refresh_token = login
+
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    data = {"date": "20230101", "amount": 1, "description": "test_description"}
+    response = client.post(url, data=data, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 400
+    assert data["date"][0] == "Date의 포멧이 잘못되었습니다. 이 형식들 중 한가지를 사용하세요: YYYY-MM-DD."
+
+
+def test_account_book_record_create_fail_with_unauthorized_user(client, account_book, login_b):
+    url = reverse("account_book:account_book_record", kwargs={"pk": account_book.id})
+    access_token, refresh_token = login_b
+
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    data = {"date": "2023-01-01", "amount": 1, "description": "test_description"}
+    response = client.post(url, data=data, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 403
+    assert data["detail"] == "이 작업을 수행할 권한(permission)이 없습니다."
+
+
+def test_account_book_record_list_read_success(client, account_book, account_book_record, login):
+    url = reverse("account_book:account_book_record", kwargs={"pk": account_book.id})
+    access_token, refresh_token = login
+
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    response = client.get(url, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 200
+
+    assert data[0]["date"] == "2023-01-01"
+    assert data[0]["amount"] == 1
+    assert data[0]["description"] == "test_description"
+    assert data[0]["is_active"] == True
+
+
+def test_account_book_record_list_read_fail_with_unauthorized_user(client, account_book, account_book_record, login_b):
+    url = reverse("account_book:account_book_record", kwargs={"pk": account_book.id})
+    access_token, refresh_token = login_b
+
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    response = client.get(url, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 403
+    assert data["detail"] == "이 작업을 수행할 권한(permission)이 없습니다."

--- a/apps/account_book/tests/test_account_book_record_detail.py
+++ b/apps/account_book/tests/test_account_book_record_detail.py
@@ -1,0 +1,108 @@
+import json
+
+from rest_framework.reverse import reverse
+
+
+def test_account_book_record_read_success(client, account_book, account_book_record, login):
+    url = reverse(
+        "account_book:account_book_record_detail", kwargs={"pk": account_book.id, "record_pk": account_book_record.id}
+    )
+    access_token, refresh_token = login
+
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    response = client.get(url, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 200
+    assert data["account_book"] == account_book.id
+    assert data["date"] == "2023-01-01"
+    assert data["amount"] == 1
+    assert data["description"] == "test_description"
+    assert data["is_active"] == True
+
+
+def test_account_book_record_read_fail_with_unauthorized_user(client, account_book, account_book_record, login_b):
+    url = reverse(
+        "account_book:account_book_record_detail", kwargs={"pk": account_book.id, "record_pk": account_book_record.id}
+    )
+    access_token, refresh_token = login_b
+
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    response = client.get(url, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 403
+    assert data["detail"] == "이 작업을 수행할 권한(permission)이 없습니다."
+
+
+def test_account_book_record_update_success(client, account_book, account_book_record, login):
+    url = reverse(
+        "account_book:account_book_record_detail", kwargs={"pk": account_book.id, "record_pk": account_book_record.id}
+    )
+    access_token, refresh_token = login
+
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    data = {"date": "1111-11-11", "amount": 111, "description": "test_description_update"}
+    response = client.patch(url, data=data, content_type="application/json", **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 200
+    assert data["amount"] == 111
+    assert data["description"] == "test_description_update"
+    assert data["updated_at"]
+
+
+def test_account_book_record_update_fail_with_no_data(client, account_book, account_book_record, login):
+    url = reverse(
+        "account_book:account_book_record_detail", kwargs={"pk": account_book.id, "record_pk": account_book_record.id}
+    )
+    access_token, refresh_token = login
+
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+    data = {
+        # "date": "1111-11-11",
+        # "amount": 111,
+        # "description": "test_description_update"
+    }
+    response = client.patch(url, data=data, content_type="application/json", **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 400
+    assert data["non_field_errors"][0] == "입력값이 없습니다."
+
+
+def test_account_book_record_delete_success(client, account_book, account_book_record, login):
+    url = reverse(
+        "account_book:account_book_record_detail", kwargs={"pk": account_book.id, "record_pk": account_book_record.id}
+    )
+    access_token, refresh_token = login
+
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+
+    response = client.delete(url, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 200
+    assert data["is_active"] == False
+    assert data["deleted_at"]
+
+
+def test_account_book_record_delete_fail_with_deleted_account_book_record(
+    client, account_book, deleted_account_book_record, login
+):
+    url = reverse(
+        "account_book:account_book_record_detail",
+        kwargs={"pk": account_book.id, "record_pk": deleted_account_book_record.id},
+    )
+    access_token, refresh_token = login
+
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+
+    response = client.delete(url, **headers)
+
+    assert response.status_code == 404

--- a/apps/account_book/tests/test_deleted_account_book.py
+++ b/apps/account_book/tests/test_deleted_account_book.py
@@ -1,0 +1,19 @@
+import json
+
+from rest_framework.reverse import reverse
+
+
+def test_deleted_account_book_list_read_success(client, deleted_account_book, login):
+    url = reverse("account_book:deleted_account_book")
+
+    access_token, refresh_token = login
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+
+    response = client.get(url, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 200
+    assert data[0]["title"] == "test_title_deleted"
+    assert data[0]["balance"] == 0
+    assert data[0]["is_active"] == False

--- a/apps/account_book/tests/test_deleted_account_book_restore_or_hard_delete.py
+++ b/apps/account_book/tests/test_deleted_account_book_restore_or_hard_delete.py
@@ -1,0 +1,55 @@
+import json
+
+from rest_framework.reverse import reverse
+
+
+def test_deleted_account_book_delete_success(client, deleted_account_book, login):
+    url = reverse("account_book:deleted_account_book_restore_or_hard_delete", kwargs={"pk": deleted_account_book.id})
+
+    access_token, refresh_token = login
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+
+    response = client.delete(url, **headers)
+
+    assert response.status_code == 204
+
+
+def test_deleted_account_book_delete_fail_with_not_deleted_account_book(client, account_book, login):
+    url = reverse("account_book:deleted_account_book_restore_or_hard_delete", kwargs={"pk": account_book.id})
+
+    access_token, refresh_token = login
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+
+    response = client.delete(url, **headers)
+    data = json.loads(response.content)
+
+    assert response.status_code == 404
+    assert data["detail"] == "찾을 수 없습니다."
+
+
+def test_deleted_account_book_update_success(client, deleted_account_book, login):
+    url = reverse("account_book:deleted_account_book_restore_or_hard_delete", kwargs={"pk": deleted_account_book.id})
+
+    access_token, refresh_token = login
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+
+    response = client.patch(url, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 200
+    assert data["is_active"] == True
+
+
+def test_deleted_account_book_update_fail_with_not_deleted_account_book(client, account_book, login):
+    url = reverse("account_book:deleted_account_book_restore_or_hard_delete", kwargs={"pk": account_book.id})
+
+    access_token, refresh_token = login
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
+
+    response = client.patch(url, **headers)
+
+    data = json.loads(response.content)
+
+    assert response.status_code == 404
+    assert data["detail"] == "찾을 수 없습니다."

--- a/apps/account_book/urls.py
+++ b/apps/account_book/urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
     path(
         "/deleted/<int:pk>",
         DeletedAccountBookRestoreOrHardDeleteView.as_view(),
-        name="deletd_account_book_restore_or_hard_delete",
+        name="deleted_account_book_restore_or_hard_delete",
     ),
     path("/<int:pk>", AccountBookDetailView.as_view(), name="account_book_detail"),
     path("/<int:pk>/records", AccountBookRecordView.as_view(), name="account_book_record"),


### PR DESCRIPTION
### Types of changes

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 테스트케이스
- [ ] 컨벤션 수정
- [ ] 문서
- [ ] CI/CD
- [ ] 리팩토링

### Summary

- 가계부, 가계부 메모의 테스트코드를 작성합니다.

<br>

- 가계부 상세 조회 성공
- 가계부 상세 조회 실패 (인증)

<br>

- 가계부 수정 성공
- 가계부 수정 실패 (입력값 없음)

<br>

- 가계부 삭제(soft delete) 성공
- 가계부 삭제 실패 (삭제된 가계부로 삭제요청)

<br>

- 삭제된 가계부 목록 조회 성공

<br>

- 삭제된 가계부 복구 성공
- 삭제된 가계부 복구 실패 (삭제되지않은 가계부로 복구 요청)

<br>

- 삭제된 가계부 완전삭제 성공
- 삭제된 가계부 완전삭제 실패 (삭제되지 않은 가계부로 완전삭제 요청)

<br>

- 가계부 메모 생성 성공
- 가계부 메모 생성 실패 (인증)
- 가계부 메모 생성 실패 (입력값 없음)
- 가계부 메모 생성 실패 (잘못된 date format)

<br>

- 가계부 메모 목록 조회 성공
- 가계부 메모 목록 조회 실패 (인증)

<br>

- 가계부 메모 상세 조회 성공
- 가계부 메모 상세 조회 실패 (인증)

<br>

- 가계부 메모 수정 성공
- 가계부 메모 수정 실패 (입력값 없음)

<br>

- 가계부 메모 삭제(soft delete) 성공
- 가계부 메모 삭제 실패 (삭제된 메모로 삭제 요청)

<br>

### Changes

- 


### 특이사항 (Optional)

-

### Screenshots (Optional)
<img width="1386" alt="스크린샷 2023-02-07 오후 1 51 47" src="https://user-images.githubusercontent.com/83942213/217151450-da34599e-a0f0-489a-8be2-9a208becb289.png">
